### PR TITLE
fix: 

### DIFF
--- a/src/app/pages/package-info/package-info.component.ts
+++ b/src/app/pages/package-info/package-info.component.ts
@@ -3,8 +3,8 @@ import { ActivatedRoute } from '@angular/router';
 import { PackageDetails } from './types';
 import { MarkdownModule } from 'ngx-markdown';
 import { PackageInfoService } from './services/package-info.service';
-import { LoadingComponent } from "../../shared/loading/loading.component";
-import { ErrorComponent } from "../../shared/error/error.component";
+import { LoadingComponent } from '../../shared/loading/loading.component';
+import { ErrorComponent } from '../../shared/error/error.component';
 
 @Component({
   selector: 'app-package-info',
@@ -24,7 +24,7 @@ export class PackageInfoComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.paramMap.subscribe((params) => {
-      const packageName = params.get('packageName');
+      const packageName = decodeURIComponent(String(params.get('packageName')));
       if (packageName) {
         this.title = `${packageName}`;
         document.title = packageName;

--- a/src/app/pages/search-results/search-results.component.html
+++ b/src/app/pages/search-results/search-results.component.html
@@ -9,9 +9,14 @@
     </h2>
     <ul class="list-group">
       @if (results?.length) { @for (result of results; track result.name) {
-      <div class="d-flex justify-content-between align-items-center border rounded my-2 p-2">
+      <div
+        class="d-flex justify-content-between align-items-center border rounded my-2 p-2"
+      >
         <div>
-          <a href="/packages/{{ result.name }}" class="text-decoration-none">
+          <a
+            [routerLink]="['/packages', getEncodedPackageName(result.name)]"
+            class="text-decoration-none"
+          >
             {{ result.name }} (v{{ result.version }})
           </a>
           <p class="mb-0">{{ result.description }}</p>

--- a/src/app/pages/search-results/search-results.component.ts
+++ b/src/app/pages/search-results/search-results.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { PackageSummary } from './services/types';
 import { SearchPackagesService } from './services/search-packages.service';
 import { LoadingComponent } from '../../shared/loading/loading.component';
@@ -7,7 +7,7 @@ import { ErrorComponent } from '../../shared/error/error.component';
 
 @Component({
   selector: 'app-search-results',
-  imports: [LoadingComponent, ErrorComponent],
+  imports: [LoadingComponent, ErrorComponent, RouterModule],
   templateUrl: './search-results.component.html',
 })
 export class SearchResultsComponent implements OnInit {
@@ -20,6 +20,10 @@ export class SearchResultsComponent implements OnInit {
     @Inject(ActivatedRoute) private route: ActivatedRoute,
     private searchPackagesService: SearchPackagesService
   ) {}
+  
+  getEncodedPackageName(packageName: string): string {
+    return encodeURIComponent(packageName);
+  }
 
   ngOnInit() {
     this.route.queryParams.subscribe((params) => {


### PR DESCRIPTION
Resolves #5 

This PR resolves issue causing packages with a "/" in their name to crash the application. This solution was achieved by encoding the package name so that "/" use their encoded representation instead (`%2F`).

In the `PackageDetailsComponent` constructor, the `decodeURIComponent` function is used to retrieve the original package name from the URL. 